### PR TITLE
added clean_test option to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -49,3 +49,6 @@ help:
 clean:
 	rm build/*.o
 
+clean_test:
+	rm $(TEST_OBJECT) $(TESTER)
+


### PR DESCRIPTION
makefile now has clean_test to remove the test object and executable
test/tester executable is no longer in the repository